### PR TITLE
export types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mocks",
     "test"
   ],
+  "types": "fakerator.d.ts",
   "author": "Icebob",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mocks",
     "test"
   ],
-  "types": "fakerator.d.ts",
+  "types": "./fakerator.d.ts",
   "author": "Icebob",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This adds the typescript types to the manifest, so that typescript knows the types of the package exports.