### PR TITLE
Add random digit string to fakerator

### DIFF
--- a/lib/fakerator.js
+++ b/lib/fakerator.js
@@ -45,6 +45,16 @@ module.exports = function(locale) {
 			return self.random.number(9);
 		},
 
+		stringDigit(length) {
+			let result = "";
+			let options = "0123456789";
+			let optionsLength = options.length;
+			for (let i = 0; i < length; i++) {
+				result += options.charAt(Math.floor(Math.random() * optionsLength));
+			}
+			return result;
+		},
+
 		hex(len = 1) {
 			let res = [];
 			for(let i = 0; i < len; i++)

--- a/test/specs/random.spec.js
+++ b/test/specs/random.spec.js
@@ -84,4 +84,9 @@ describe("Fakerator.random", () => {
 		expect(fakerator.random.string({ min: 5, max: 10 })).to.be.length(5);
 	});
 
+	it("check random.stringDigit function", () => {
+		expect(fakerator.random.stringDigit(10)).to.be.length(10);
+		expect(fakerator.random.stringDigit(8)).to.be.a("String").length(8);
+	});
+
 });


### PR DESCRIPTION
I couldn't find a way to have fakerator generate a random string of numbers, only mixed characters. So I created a function to do that for anyone that might need it (including me). I think it's a good addition but if not, no worries. 